### PR TITLE
Update chunk loading for simplex noise terrain. Fix camera clipping a…

### DIFF
--- a/source/Player/Player.h
+++ b/source/Player/Player.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "../Renderer/Renderer.h"
+#include "../blocks/ChunkManager.h"
 #include "../models/VoxelCharacter.h"
 #include "../Lighting/LightingManager.h"
 #include "../Particles/BlockParticleManager.h"
@@ -25,7 +26,7 @@ class Player
 {
 public:
 	/* Public methods */
-	Player(Renderer* pRenderer, QubicleBinaryManager* pQubicleBinaryManager, LightingManager* pLightingManager, BlockParticleManager* pBlockParticleManager);
+	Player(Renderer* pRenderer, ChunkManager* pChunkManager, QubicleBinaryManager* pQubicleBinaryManager, LightingManager* pLightingManager, BlockParticleManager* pBlockParticleManager);
 	~Player();
 
 	// Get voxel character pointer
@@ -49,8 +50,14 @@ public:
 	// Collision
 	bool CheckCollisions(vec3 positionCheck, vec3 previousPosition, vec3 *pNormal, vec3 *pMovement);
 
+	// World
+	void UpdateGridPosition();
+	Chunk* GetCachedGridChunkOrFromPosition(vec3 pos);
+	void ClearChunkCacheForChunk(Chunk* pChunk);
+
 	// Movement
-	void MoveAbsolute(vec3 direction, const float speed, bool shouldChangeForward = true);
+	vec3 GetPositionMovementAmount();
+	vec3 MoveAbsolute(vec3 direction, const float speed, bool shouldChangeForward = true);
 	void Move(const float speed);
 	void Strafe(const float speed);
 	void Levitate(const float speed);
@@ -103,6 +110,7 @@ protected:
 private:
 	/* Private members */
 	Renderer* m_pRenderer;
+	ChunkManager* m_pChunkManager;
 	QubicleBinaryManager* m_pQubicleBinaryManager;
 	LightingManager* m_pLightingManager;
 	BlockParticleManager* m_pBlockParticleManager;
@@ -118,6 +126,18 @@ private:
 
 	// The direction of gravity for the player
 	vec3 m_gravityDirection;
+
+	// Keep track of how much we have changed position in the update, based on physics, etc.
+	// So that the fake camera position can be updated, if we are in some kind of follow camera mode.
+	vec3 m_positionMovementAmount;
+
+	// Grid position
+	int m_gridPositionX;
+	int m_gridPositionY;
+	int m_gridPositionZ;
+
+	// Cached chunk from grid position
+	Chunk* m_pCachedGridChunk;
 
 	// Flag to control if we are allowed to jump or not, reset when landing
 	bool m_bCanJump;

--- a/source/VoxCamera.cpp
+++ b/source/VoxCamera.cpp
@@ -166,20 +166,60 @@ void VoxGame::UpdateCameraClipping(float dt)
 	{
 		int numIterations = 0;
 		int maxNumIterations = 100;
+		vec3 basePos;
+		vec3 testPos;
+		vec3 cameraFacingUnit = normalize(m_pGameCamera->GetFacing());
 		bool collides = true;
+		int blockX, blockY, blockZ;
+		vec3 blockPos;
+		bool active = false;
 		vec3 toPlayer = ((m_pPlayer->GetCenter() + Player::PLAYER_CENTER_OFFSET) - m_pGameCamera->GetFakePosition());
 		float distance = length(toPlayer);
 		float incrementAmount = distance / maxNumIterations;
 		while (collides == true && numIterations < maxNumIterations)
 		{
-			if (cameraPosition.y < 0.0f)
+			collides = false;
+			basePos = cameraPosition;
+
+			vec3 playerRight = m_pPlayer->GetRightVector() * 0.25f;
+			testPos = basePos + playerRight;
+			Chunk* pChunk = NULL;
+			active = m_pChunkManager->GetBlockActiveFrom3DPosition(testPos.x, testPos.y, testPos.z, &blockPos, &blockX, &blockY, &blockZ, &pChunk);
+			if (active)
 			{
-				cameraPosition += m_pGameCamera->GetFacing() * incrementAmount;
 				collides = true;
 			}
-			else
+
+			playerRight = m_pPlayer->GetRightVector() * -0.25f;
+			testPos = basePos + playerRight;
+			pChunk = NULL;
+			active = m_pChunkManager->GetBlockActiveFrom3DPosition(testPos.x, testPos.y, testPos.z, &blockPos, &blockX, &blockY, &blockZ, &pChunk);
+			if (active)
 			{
-				collides = false;
+				collides = true;
+			}
+
+			vec3 playerUp = m_pPlayer->GetUpVector() * -0.25f;
+			testPos = basePos + playerUp;
+			pChunk = NULL;
+			active = m_pChunkManager->GetBlockActiveFrom3DPosition(testPos.x, testPos.y, testPos.z, &blockPos, &blockX, &blockY, &blockZ, &pChunk);
+			if (active)
+			{
+				collides = true;
+			}
+
+			playerUp = m_pPlayer->GetUpVector() * 0.25f;
+			testPos = basePos + playerUp;
+			pChunk = NULL;
+			active = m_pChunkManager->GetBlockActiveFrom3DPosition(testPos.x, testPos.y, testPos.z, &blockPos, &blockX, &blockY, &blockZ, &pChunk);
+			if (active)
+			{
+				collides = true;
+			}
+
+			if (collides == true)
+			{
+				cameraPosition += m_pGameCamera->GetFacing() * incrementAmount;
 			}
 
 			numIterations++;

--- a/source/VoxControls.cpp
+++ b/source/VoxControls.cpp
@@ -157,8 +157,8 @@ void VoxGame::UpdateKeyboardControls(float dt)
 			bool shouldChangePlayerFacing = (m_cameraMode != CameraMode_FirstPerson);
 
 			m_movementDirection = normalize(m_movementDirection);
-			m_pGameCamera->SetFakePosition(m_pGameCamera->GetFakePosition() + m_movementDirection * m_movementSpeed * dt);
-			m_pPlayer->MoveAbsolute(m_movementDirection, m_movementSpeed * dt, shouldChangePlayerFacing);
+			vec3 amountMoved = m_pPlayer->MoveAbsolute(m_movementDirection, m_movementSpeed * dt, shouldChangePlayerFacing);
+			m_pGameCamera->SetFakePosition(m_pGameCamera->GetFakePosition() + amountMoved);
 		}
 	}
 }
@@ -292,8 +292,8 @@ void VoxGame::UpdateGamePadControls(float dt)
 			bool shouldChangePlayerFacing = (m_cameraMode != CameraMode_FirstPerson);
 
 			m_movementDirection = normalize(m_movementDirection);
-			m_pGameCamera->SetFakePosition(m_pGameCamera->GetFakePosition() + m_movementDirection * m_movementSpeed * dt);
- 			m_pPlayer->MoveAbsolute(m_movementDirection, m_movementSpeed * dt, shouldChangePlayerFacing);
+			vec3 amountMoved = m_pPlayer->MoveAbsolute(m_movementDirection, m_movementSpeed * dt, shouldChangePlayerFacing);
+			m_pGameCamera->SetFakePosition(m_pGameCamera->GetFakePosition() + amountMoved);
 		}
 	}
 }

--- a/source/VoxGame.cpp
+++ b/source/VoxGame.cpp
@@ -138,7 +138,7 @@ void VoxGame::Create(VoxSettings* pVoxSettings)
 	m_pBlockParticleManager = new BlockParticleManager(m_pRenderer);
 
 	/* Create the player */
-	m_pPlayer = new Player(m_pRenderer, m_pQubicleBinaryManager, m_pLightingManager, m_pBlockParticleManager);
+	m_pPlayer = new Player(m_pRenderer, m_pChunkManager, m_pQubicleBinaryManager, m_pLightingManager, m_pBlockParticleManager);
 
 	/* Create the frontend manager */
 	m_pFrontendManager = new FrontendManager(m_pRenderer);

--- a/source/VoxRender.cpp
+++ b/source/VoxRender.cpp
@@ -90,7 +90,7 @@ void VoxGame::Render()
 			}
 
 			// Render world
-			RenderWorld();
+			//RenderWorld();
 
 			// Render the chunks
 			m_pChunkManager->Render();

--- a/source/VoxUpdate.cpp
+++ b/source/VoxUpdate.cpp
@@ -44,6 +44,12 @@ void VoxGame::Update()
 
 		// Player
 		m_pPlayer->Update(m_deltaTime);
+
+		if (m_cameraMode == CameraMode_MouseRotate || m_cameraMode == CameraMode_AutoCamera)
+		{
+			vec3 playerMovementChanged = m_pPlayer->GetPositionMovementAmount();
+			m_pGameCamera->SetFakePosition(m_pGameCamera->GetFakePosition() + playerMovementChanged);
+		}
 	}
 
 	// Update the chunk manager

--- a/source/blocks/Chunk.cpp
+++ b/source/blocks/Chunk.cpp
@@ -13,6 +13,7 @@
 #include "ChunkManager.h"
 #include "../models/QubicleBinary.h"
 #include "../Utils/Random.h"
+#include "../Simplex/simplexnoise.h"
 
 const float Chunk::BLOCK_RENDER_SIZE = 0.5f;
 const float Chunk::CHUNK_RADIUS = sqrt(((CHUNK_SIZE * Chunk::BLOCK_RENDER_SIZE*2.0f)*(CHUNK_SIZE * Chunk::BLOCK_RENDER_SIZE*2.0f))*2.0f) / 2.0f + ((Chunk::BLOCK_RENDER_SIZE*2.0f)*2.0f);
@@ -86,12 +87,19 @@ void Chunk::Setup()
 		{
 			for (int y = 0; y < CHUNK_SIZE; y++)
 			{
+				float xPosition = m_position.x + x;
+				float yPosition = m_position.y + y;
+				float zPosition = m_position.z + z;
+
 				float red = 1.0f;
 				float green = 1.0f;
 				float blue = 1.0f;
 				float alpha = 1.0f;
 
-				if (GetRandomNumber(0, 100) > 95)
+				float noise = octave_noise_3d(4.0f, 0.3f, 0.05f, xPosition, yPosition, zPosition);
+
+				if (noise > 0.25f)
+				//if (y < 8)
 				{
 					SetColour(x, y, z, red, green, blue, alpha);
 				}
@@ -1049,6 +1057,8 @@ void Chunk::RenderDebug()
 
 	m_pRenderer->PushMatrix();
 		m_pRenderer->TranslateWorldMatrix(m_position.x, m_position.y, m_position.z);
+		m_pRenderer->TranslateWorldMatrix(Chunk::CHUNK_SIZE*Chunk::BLOCK_RENDER_SIZE, Chunk::CHUNK_SIZE*Chunk::BLOCK_RENDER_SIZE, Chunk::CHUNK_SIZE*Chunk::BLOCK_RENDER_SIZE);
+		m_pRenderer->TranslateWorldMatrix(-Chunk::BLOCK_RENDER_SIZE, -Chunk::BLOCK_RENDER_SIZE, -Chunk::BLOCK_RENDER_SIZE);
 
 		m_pRenderer->ImmediateColourAlpha(1.0f, 1.0f, 0.0f, 1.0f);
 		if (IsEmpty())
@@ -1105,10 +1115,12 @@ void Chunk::RenderDebug()
 void Chunk::Render2D(Camera* pCamera, unsigned int viewport, unsigned int font)
 {
 	int winx, winy;
+	vec3 centerPos = m_position + vec3(Chunk::CHUNK_SIZE*Chunk::BLOCK_RENDER_SIZE, Chunk::CHUNK_SIZE*Chunk::BLOCK_RENDER_SIZE, Chunk::CHUNK_SIZE*Chunk::BLOCK_RENDER_SIZE);
+	centerPos += vec3(-Chunk::BLOCK_RENDER_SIZE, -Chunk::BLOCK_RENDER_SIZE, -Chunk::BLOCK_RENDER_SIZE);
 	m_pRenderer->PushMatrix();
 		m_pRenderer->SetProjectionMode(PM_PERSPECTIVE, viewport);
 		pCamera->Look();
-		m_pRenderer->GetScreenCoordinatesFromWorldPosition(m_position, &winx, &winy);
+		m_pRenderer->GetScreenCoordinatesFromWorldPosition(centerPos, &winx, &winy);
 	m_pRenderer->PopMatrix();
 
 	bool renderChunkGrid = true;

--- a/source/blocks/ChunkManager.h
+++ b/source/blocks/ChunkManager.h
@@ -74,6 +74,9 @@ public:
 	Chunk* GetChunkFromPosition(float posX, float posY, float posZ);
 	Chunk* GetChunk(int aX, int aY, int aZ);
 
+	// Getting the active block state given a position and chunk information
+	bool GetBlockActiveFrom3DPosition(float x, float y, float z, vec3 *blockPos, int* blockX, int* blockY, int* blockZ, Chunk** pChunk);
+
 	// Rendering modes
 	void SetWireframeRender(bool wireframe);
 


### PR DESCRIPTION
…nd player collisions with the world.

Dont render the old world plan any more.

Return the amount of movement done to player position for control
movement and also velocity movement, so that the fake camera position
can be updated, and clipping can work properly.